### PR TITLE
feat: add runtime AI provider config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Environment variables for DreamTales
+AI_PROVIDER=
+AI_API_KEY=
+

--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ Nuxt 3 PWA for generating safe bedtime stories.
 
 ```bash
 npm install
+```
+
+## Miljövariabler & körning
+
+Create a `.env` file in the project root:
+
+```bash
+AI_PROVIDER=<provider name>
+AI_API_KEY=<your API key>
+```
+
+Run the development server:
+
+```bash
 npm run dev
 ```
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,4 +2,13 @@
 export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
   devtools: { enabled: true },
+  runtimeConfig: {
+    ai: {
+      provider: '',
+      apiKey: '',
+    },
+    public: {
+      appName: 'DreamTales',
+    },
+  },
 });


### PR DESCRIPTION
## Context
- need runtime configuration for AI provider and public app name

## What changed
- add `runtimeConfig` with AI provider settings and public app name
- document `AI_PROVIDER` and `AI_API_KEY` variables in README
- scaffold `.env.example` for local setup

## Why
- keeps provider and key out of source control and enables runtime selection

## Screenshots
- n/a

## Risk
- low: config defaults are empty

## Roll-back
- revert commit

------
https://chatgpt.com/codex/tasks/task_e_68a097f14c8c832686725d420af45177