### PR TITLE
feat: add story types and word target helper

### DIFF
--- a/lib/ai/wordTargets.ts
+++ b/lib/ai/wordTargets.ts
@@ -1,0 +1,12 @@
+import type { StoryLength } from '@/types/story'
+
+export function wordTargetFor(length: StoryLength) {
+  switch (length) {
+    case 'short':
+      return { min: 300, max: 400 }
+    case 'medium':
+      return { min: 500, max: 700 }
+    case 'long':
+      return { min: 900, max: 1100 }
+  }
+}

--- a/types/story.ts
+++ b/types/story.ts
@@ -1,0 +1,18 @@
+export type StoryLength = 'short' | 'medium' | 'long'
+export type Lang = 'sv' | 'en'
+
+export interface StoryMeta {
+  language: Lang
+  length: StoryLength
+  wordTarget: { min: number; max: number }
+  tone?: 'cozy' | 'silly' | 'adventurous' | 'calm'
+  readingLevel?: 'simple' | 'normal'
+  windDown?: boolean
+}
+
+export interface StoryRecord {
+  id: string
+  createdAt: string
+  text: string
+  meta: StoryMeta
+}


### PR DESCRIPTION
## Context
Setting up core typing and word count utilities for story generation.

## What changed
- add StoryLength, Lang, StoryMeta and StoryRecord types
- add wordTargetFor helper mapping lengths to word ranges

## Why
Provides typed metadata and word count targets needed for story generation logic.

## Screenshots
N/A

## Risk
Low – new types and pure utility function.

## Roll-back
Revert this commit.

### Usage
```ts
import { wordTargetFor } from '@/lib/ai/wordTargets'
import type { StoryMeta } from '@/types/story'

const meta: StoryMeta = {
  language: 'sv',
  length: 'medium',
  wordTarget: wordTargetFor('medium'),
  tone: 'cozy',
  readingLevel: 'normal',
  windDown: true,
}
```


------
https://chatgpt.com/codex/tasks/task_e_68a0c44d3e58832696776aa9600e1aaf