### PR TITLE
feat: add basic ai safety utilities

### DIFF
--- a/lib/ai/safety.ts
+++ b/lib/ai/safety.ts
@@ -1,0 +1,55 @@
+type Lang = 'sv' | 'en'
+
+type SafetyResult = 'ok' | { reason: string }
+
+const patterns: Record<Lang, RegExp[]> = {
+  sv: [
+    /\bdöda/i,
+    /\bblod/i,
+    /\bmord/i,
+    /\bsex/i,
+    /\bporr/i,
+    /\bnaken/i,
+    /\bjävla/i,
+    /\bhora/i,
+    /\bbög/i,
+    /\bneger/i,
+  ],
+  en: [
+    /\bkill/i,
+    /\bblood/i,
+    /\bgore/i,
+    /\bmurder/i,
+    /\bsex/i,
+    /\bporn/i,
+    /\bnude/i,
+    /\bfuck/i,
+    /\bshit/i,
+    /\bbitch/i,
+    /\bnigger/i,
+    /\bfaggot/i,
+  ],
+}
+
+function scan(text: string, lang: Lang): SafetyResult {
+  const lower = text.toLowerCase()
+  for (const re of patterns[lang]) {
+    if (re.test(lower)) return { reason: 'contains disallowed content' }
+  }
+  return 'ok'
+}
+
+/** Pre-check user prompt for obvious unsafe content */
+export function preModerate(prompt: string, lang: Lang): SafetyResult {
+  return scan(prompt, lang)
+}
+
+/** Scan generated text for unsafe content */
+export function postScan(text: string, lang: Lang): SafetyResult {
+  return scan(text, lang)
+}
+
+/** Slightly tighten the system prompt for a safety retry */
+export function tightenSystemPrompt(base: string): string {
+  return `${base}\nEnsure the story is gentle and free of violence, gore, adult themes, or slurs.`
+}


### PR DESCRIPTION
## Context
Add minimal safety checks for prompts and generated stories.

## What changed
- add `/lib/ai/safety.ts` with pre-generation moderation, post-generation scan, and system prompt tightening helpers

## Why
Baseline guardrails against violent, adult, or hateful content in generated stories.

## Screenshots
N/A

## Risk
Low – new module is self‑contained and not yet wired into runtime.

## Roll-back
Revert the commit.

```ts
import { preModerate, postScan, tightenSystemPrompt } from '@/lib/ai/safety'

const prompt = 'Berätta en saga om drakar'
if (preModerate(prompt, 'sv') !== 'ok') {
  throw new Error('Unsafe prompt')
}
const system = tightenSystemPrompt('You are a kind storyteller')
const text = await generateText({ system, user: prompt, target: { min: 300, max: 400 } })
if (postScan(text, 'sv') !== 'ok') {
  throw new Error('Unsafe output')
}
```

------
https://chatgpt.com/codex/tasks/task_e_68a0c495e5dc83269923733c669bc151